### PR TITLE
(Add) instructions for runtime directory when using Unix sockets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,8 +122,8 @@ LISTENING_PORT=6969
 # reverse proxy.
 #
 # Default: <commented out>
-# Example: "/run/unit3d-announce.sock"
-# LISTENING_UNIX_SOCKET="/run/unit3d-announce.sock"
+# Example: "/run/unit3d-announce/unit3d-announce.sock"
+# LISTENING_UNIX_SOCKET="/run/unit3d-announce/unit3d-announce.sock"
 
 # Open a connection to the incoming peer announcing and record if their socket
 # accepts the connection.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Paste the following `location` block into the first `server` block immediately a
         proxy_set_header Host $host;
         # Uncomment one of the following:
         # proxy_pass http://aaa.bbb.ccc.ddd:eee$request_uri;
-        # proxy_pass http://unix:/run/unit3d-announce.sock;
+        # proxy_pass http://unix:/run/unit3d-announce/unit3d-announce.sock;
         real_ip_header X-Forwarded-For;
         real_ip_recursive on;
         set_real_ip_from fff.ggg.hhh.iii;
@@ -92,7 +92,7 @@ Paste the following `location` block into the first `server` block immediately a
 ```
 
 - `aaa.bbb.ccc.ddd:eeee` is the local listening IP address and port of UNIT3D-Announce if listening on TCP sockets. Set this to the `LISTENING_IP_ADDRESS` and `LISTENING_PORT` configured in the .env file.
-- `http://unix:/run/unit3d-announce.sock` is the local listening unix socket if listening on unix sockets. Set the path of this (`/run/unit3d-announce.sock`) to `LISTENING_UNIX_SOCKET` configured in the .env file.
+- `http://unix:/run/unit3d-announce/unit3d-announce.sock` is the local listening unix socket if listening on unix sockets. Set the path of this (`/run/unit3d-announce/unit3d-announce.sock`) to `LISTENING_UNIX_SOCKET` configured in the .env file.
 - `fff.ggg.hhh.iii` is the public listening IP address of the nginx proxy used for accessing the frontend website. You can add additional `set_real_ip_from jjj.kkk.lll.mmm/nn;` lines for each additional proxy used so long as the proxy appends the proper values to the `X-Forwarded-For` header. Replace this with your proxy IP address.
 
 Uncomment and set `REVERSE_PROXY_CLIENT_IP_HEADER_NAME` in the .env file to `X-Real-IP`.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ redirect_stderr=true
 stdout_logfile=/var/www/html/storage/logs/announce.log
 ```
 
+**Set Up Runtime Directory (if using Unix sockets):**
+
+If using Unix sockets, create a `/run` directory for `ubuntu` user:
+1. `sudo nano /etc/tmpfiles.d/unit3d-announce.conf`
+2. Add: `d /run/unit3d-announce 0755 ubuntu www-data -`
+3. Run: `sudo systemd-tmpfiles --create`
+
 ### Starting/Restarting UNIT3D-Announce
 
 Reload supervisor


### PR DESCRIPTION
Needed as `/run` is root-owned, and `supervisord` lacks the capability to create/prepare the environment as root first (unlike `systemd`). With this, the socket file survives across reboots with correct perms.