### PR TITLE
feat: add lifetime donor download slot override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -224,3 +224,11 @@ USER_RECEIVE_LEECH_LIST_RATE_LIMITS = "60=20;900=50;7200=250;86400=1000;604800=5
 # Default: <commented out>
 # Example: 100
 # LIFETIME_DONOR_DOWNLOAD_FACTOR_OVERRIDE=100
+
+# If specified, this will override the download slot limit for lifetime
+# donors to the specified value. If unspecified, lifetime donors will have
+# unlimited download slots.
+#
+# Default: <commented out>
+# Example: 50
+# LIFETIME_DONOR_DOWNLOAD_SLOTS_OVERRIDE=50

--- a/src/announce.rs
+++ b/src/announce.rs
@@ -439,9 +439,16 @@ pub async fn announce(
             return Err(GroupNotEnabled(group.slug));
         }
 
-        // Make sure user isn't leeching more torrents than their group allows
+        // Make sure user isn't leeching more torrents than their group allows.
+        // Lifetime donors get unlimited slots unless overridden via config.
         let has_hit_download_slot_limit = if queries.left > 0 {
-            if let Some(slots) = group.download_slots {
+            let effective_slots = if user.is_lifetime {
+                config.lifetime_donor_download_slots_override
+            } else {
+                group.download_slots
+            };
+
+            if let Some(slots) = effective_slots {
                 user.num_leeching >= slots
             } else {
                 false

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,6 +124,9 @@ pub struct Config {
     /// If specified, this will override the download factor of the user's
     /// group. The factor is stored as a percentage.
     pub lifetime_donor_download_factor_override: Option<u8>,
+    /// If specified, this will override the download slot limit for lifetime
+    /// donors. If unspecified, lifetime donors have unlimited download slots.
+    pub lifetime_donor_download_slots_override: Option<u32>,
 }
 
 impl Config {
@@ -341,6 +344,16 @@ impl Config {
             "LIFETIME_DONOR_DOWNLOAD_FACTOR_OVERRIDE must be a number between 0 and 2^8 - 1, if provided",
         )?;
 
+        let lifetime_donor_download_slots_override = env::var(
+            "LIFETIME_DONOR_DOWNLOAD_SLOTS_OVERRIDE",
+        )
+        .ok()
+        .map(|s| s.parse())
+        .transpose()
+        .context(
+            "LIFETIME_DONOR_DOWNLOAD_SLOTS_OVERRIDE must be be a number between 0 and 2^32 - 1, if provided",
+        )?;
+
         let apikey = env::var("APIKEY").context("APIKEY not found in .env file.")?;
 
         if apikey.len() < 32 {
@@ -379,6 +392,7 @@ impl Config {
             lifetime_donor_immunity_override,
             lifetime_donor_upload_factor_override,
             lifetime_donor_download_factor_override,
+            lifetime_donor_download_slots_override,
         })
     }
 


### PR DESCRIPTION
This PR adds an unlimited default AND configurable download slot override for Lifetime Donors that matches UNIT3D's expected behavior. See: 
- [donation/index.blade.php#L48](https://github.com/HDInnovations/UNIT3D/blob/8b88f4c8182eb3d3912ffef425c3224dcfd596f4/resources/views/donation/index.blade.php#L48)
- [(Fix) Lifetime donor download slot check#5272](https://github.com/HDInnovations/UNIT3D/pull/5272)

Currently, the download slot limit is determined solely by the user's group with no consideration for lifetime donor status. This means lifetime donors are subject to the same slot restrictions regardless of the aforementioned lifetime donor advertisement.

To still allow some owner/operator discretion, this PR introduces a LIFETIME_DONOR_DOWNLOAD_SLOTS_OVERRIDE config option that allows defining a slot limit with `LIFETIME_DONOR_DOWNLOAD_SLOTS_OVERRIDE` or unlimited if left unset.