### PR TITLE
feat: dual-stack (IPv4/IPv6) peer support

### DIFF
--- a/.sqlx/query-b1ec8a6b388f2084b1170573c7eebbfefd6505507a95810ba82665953a20bd82.json
+++ b/.sqlx/query-b1ec8a6b388f2084b1170573c7eebbfefd6505507a95810ba82665953a20bd82.json
@@ -1,6 +1,6 @@
 {
   "db_name": "MySQL",
-  "query": "\n                SELECT\n                    INET6_NTOA(peers.ip) as `ip_address: IpAddr`,\n                    peers.user_id as `user_id: u32`,\n                    peers.torrent_id as `torrent_id: u32`,\n                    peers.port as `port: u16`,\n                    peers.seeder as `is_seeder: bool`,\n                    peers.active as `is_active: bool`,\n                    peers.visible as `is_visible: bool`,\n                    peers.connectable as `is_connectable: bool`,\n                    peers.updated_at as `updated_at: DateTime<Utc>`,\n                    peers.uploaded as `uploaded: u64`,\n                    peers.downloaded as `downloaded: u64`,\n                    peers.peer_id as `peer_id: PeerId`\n                FROM\n                    peers\n            ",
+  "query": "\n                SELECT\n                    INET6_NTOA(peers.ip) as `ip_address: IpAddr`,\n                    peers.user_id as `user_id: u32`,\n                    peers.torrent_id as `torrent_id: u32`,\n                    peers.port as `port: u16`,\n                    peers.seeder as `is_seeder: bool`,\n                    peers.active as `is_active: bool`,\n                    peers.visible as `is_visible: bool`,\n                    peers.connectable as `is_connectable: bool`,\n                    peers.updated_at as `updated_at: DateTime<Utc>`,\n                    peers.uploaded as `uploaded: u64`,\n                    peers.downloaded as `downloaded: u64`,\n                    peers.peer_id as `peer_id: PeerId`,\n                    INET6_NTOA(peers.ipv4) as `ipv4_address: Option<IpAddr>`,\n                    peers.ipv4_port as `ipv4_port: Option<u16>`,\n                    peers.ipv4_connectable as `ipv4_connectable: Option<bool>`,\n                    INET6_NTOA(peers.ipv6) as `ipv6_address: Option<IpAddr>`,\n                    peers.ipv6_port as `ipv6_port: Option<u16>`,\n                    peers.ipv6_connectable as `ipv6_connectable: Option<bool>`\n                FROM\n                    peers\n            ",
   "describe": {
     "columns": [
       {
@@ -110,6 +110,60 @@
           "flags": "NOT_NULL | PRIMARY_KEY | BINARY | NO_DEFAULT_VALUE",
           "max_size": 20
         }
+      },
+      {
+        "ordinal": 12,
+        "name": "ipv4_address: Option<IpAddr>",
+        "type_info": {
+          "type": "VarString",
+          "flags": "",
+          "max_size": 156
+        }
+      },
+      {
+        "ordinal": 13,
+        "name": "ipv4_port: Option<u16>",
+        "type_info": {
+          "type": "Short",
+          "flags": "UNSIGNED",
+          "max_size": 5
+        }
+      },
+      {
+        "ordinal": 14,
+        "name": "ipv4_connectable: Option<bool>",
+        "type_info": {
+          "type": "Tiny",
+          "flags": "",
+          "max_size": 1
+        }
+      },
+      {
+        "ordinal": 15,
+        "name": "ipv6_address: Option<IpAddr>",
+        "type_info": {
+          "type": "VarString",
+          "flags": "",
+          "max_size": 156
+        }
+      },
+      {
+        "ordinal": 16,
+        "name": "ipv6_port: Option<u16>",
+        "type_info": {
+          "type": "Short",
+          "flags": "UNSIGNED",
+          "max_size": 5
+        }
+      },
+      {
+        "ordinal": 17,
+        "name": "ipv6_connectable: Option<bool>",
+        "type_info": {
+          "type": "Tiny",
+          "flags": "",
+          "max_size": 1
+        }
       }
     ],
     "parameters": {
@@ -127,8 +181,14 @@
       true,
       false,
       false,
-      false
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true
     ]
   },
-  "hash": "3e1bd0d09ba49be5266185bd8411c8ba83b05ce292ab287676be905169bf1d38"
+  "hash": "b1ec8a6b388f2084b1170573c7eebbfefd6505507a95810ba82665953a20bd82"
 }

--- a/src/announce.rs
+++ b/src/announce.rs
@@ -257,6 +257,14 @@ pub async fn announce(
     headers: HeaderMap,
     ClientIp(client_ip): ClientIp,
 ) -> Result<Vec<u8>, AnnounceError> {
+    let client_ip = match client_ip {
+        IpAddr::V6(ip) => match ip.to_ipv4_mapped() {
+            Some(ipv4) => IpAddr::V4(ipv4),
+            None => client_ip,
+        },
+        _ => client_ip,
+    };
+
     // Validate headers
     if headers.contains_key(ACCEPT_LANGUAGE)
         || headers.contains_key(REFERER)
@@ -494,6 +502,19 @@ pub async fn announce(
         } else {
             // Insert the peer into the in-memory db
             let mut old_peer: Option<Peer> = None;
+
+            let endpoint = store::peer::Endpoint {
+                ip: client_ip,
+                port: queries.port,
+                is_connectable,
+                updated_at: now,
+            };
+
+            let (ipv4_ep, ipv6_ep) = match client_ip {
+                IpAddr::V4(_) => (Some(endpoint), None),
+                IpAddr::V6(_) => (None, Some(endpoint)),
+            };
+
             let new_peer = *torrent
                 .peers
                 .entry(store::peer::Index {
@@ -503,10 +524,11 @@ pub async fn announce(
                 .and_modify(|peer| {
                     old_peer = Some(*peer);
 
-                    peer.ip_address = client_ip;
-                    peer.port = queries.port;
+                    match client_ip {
+                        IpAddr::V4(_) => peer.ipv4 = Some(endpoint),
+                        IpAddr::V6(_) => peer.ipv6 = Some(endpoint),
+                    }
                     peer.is_seeder = queries.left == 0;
-                    peer.is_connectable = is_connectable;
                     peer.is_visible =
                         peer.is_included_in_leech_list(&config) || !has_hit_download_slot_limit;
                     peer.is_active = true;
@@ -517,12 +539,11 @@ pub async fn announce(
                     peer.downloaded = queries.downloaded;
                 })
                 .or_insert(store::peer::Peer {
-                    ip_address: client_ip,
-                    port: queries.port,
+                    ipv4: ipv4_ep,
+                    ipv6: ipv6_ep,
                     is_seeder: queries.left == 0,
                     is_active: true,
                     is_visible: !has_hit_download_slot_limit,
-                    is_connectable,
                     has_sent_completed: queries.event == Event::Completed,
                     updated_at: now,
                     uploaded: queries.uploaded,
@@ -674,17 +695,23 @@ pub async fn announce(
                 }
             }
 
-            // Split peers into ipv4 and ipv6 variants and serialize their socket
-            // to bytes according to the bittorrent spec
+            // Serialize both endpoints of each peer into the compact
+            // ipv4 and ipv6 peer lists according to the bittorrent spec
             for (_, peer) in peers.iter() {
-                match peer.ip_address {
-                    IpAddr::V4(ip) => {
-                        peers_ipv4.extend(&ip.octets());
-                        peers_ipv4.extend(&peer.port.to_be_bytes());
+                if let Some(ep) = &peer.ipv4 {
+                    if !config.require_peer_connectivity || ep.is_connectable {
+                        if let IpAddr::V4(ip) = ep.ip {
+                            peers_ipv4.extend(&ip.octets());
+                            peers_ipv4.extend(&ep.port.to_be_bytes());
+                        }
                     }
-                    IpAddr::V6(ip) => {
-                        peers_ipv6.extend(&ip.octets());
-                        peers_ipv6.extend(&peer.port.to_be_bytes());
+                }
+                if let Some(ep) = &peer.ipv6 {
+                    if !config.require_peer_connectivity || ep.is_connectable {
+                        if let IpAddr::V6(ip) = ep.ip {
+                            peers_ipv6.extend(&ip.octets());
+                            peers_ipv6.extend(&ep.port.to_be_bytes());
+                        }
                     }
                 }
             }
@@ -878,6 +905,15 @@ pub async fn announce(
             });
     }
 
+    let (peer_ipv4, peer_ipv4_port, peer_ipv4_connectable) = match client_ip {
+        IpAddr::V4(_) => (Some(client_ip), Some(queries.port), Some(is_connectable)),
+        _ => (None, None, None),
+    };
+    let (peer_ipv6, peer_ipv6_port, peer_ipv6_connectable) = match client_ip {
+        IpAddr::V6(_) => (Some(client_ip), Some(queries.port), Some(is_connectable)),
+        _ => (None, None, None),
+    };
+
     state.queues.peers.lock().upsert(
         peer_update::Index {
             peer_id: queries.peer_id,
@@ -897,6 +933,12 @@ pub async fn announce(
             created_at: now,
             updated_at: now,
             connectable: is_connectable,
+            ipv4: peer_ipv4,
+            ipv4_port: peer_ipv4_port,
+            ipv4_connectable: peer_ipv4_connectable,
+            ipv6: peer_ipv6,
+            ipv6_port: peer_ipv6_port,
+            ipv6_connectable: peer_ipv6_connectable,
         },
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,8 +82,8 @@ async fn main() -> Result<()> {
         axum::serve(listener, app)
             .with_graceful_shutdown(shutdown_signal())
             .await?;
-    } else if let Some(ip) = config.listening_ip_address
-        && let Some(port) = config.listening_port
+    } else if let (Some(ip), Some(port)) =
+        (config.listening_ip_address, config.listening_port)
     {
         // Create TCP socket.
         let addr = SocketAddr::from((ip, port));

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -2,6 +2,7 @@ use std::{cmp::min, collections::VecDeque, hash::Hash, slice::Iter, sync::Arc, v
 
 pub mod announce_update;
 pub mod history_update;
+pub mod peer_deactivation;
 pub mod peer_update;
 pub mod torrent_update;
 pub mod unregistered_info_hash_update;
@@ -11,6 +12,7 @@ use crate::state::AppState;
 use futures_util::future::join_all;
 use history_update::HistoryUpdate;
 use parking_lot::Mutex;
+use peer_deactivation::PeerDeactivation;
 use peer_update::PeerUpdate;
 use ringmap::RingMap;
 use tokio::{join, time::Instant};
@@ -24,6 +26,10 @@ pub struct Queues {
     pub announces: Mutex<announce_update::Queue>,
     pub histories: Mutex<Queue<history_update::Index, HistoryUpdate>>,
     pub peers: Mutex<Queue<peer_update::Index, PeerUpdate>>,
+    /// Marks reaped peers inactive in the database. Keyed by the same primary
+    /// key as [`peers`](Self::peers) (`peer_update::Index`), it exists as a
+    /// separate queue because the reaper cannot reconstruct a full `PeerUpdate`.
+    pub peer_deactivations: Mutex<Queue<peer_update::Index, PeerDeactivation>>,
     pub torrents: Mutex<Queue<torrent_update::Index, TorrentUpdate>>,
     pub unregistered_info_hashes:
         Mutex<Queue<unregistered_info_hash_update::Index, UnregisteredInfoHashUpdate>>,
@@ -45,9 +51,17 @@ impl Queues {
             )),
             peers: Mutex::new(Queue::<peer_update::Index, PeerUpdate>::new(QueueConfig {
                 max_bindings_per_flush: 65_535,
-                bindings_per_record: 15,
+                bindings_per_record: 21,
                 extra_bindings_per_flush: 0,
             })),
+            peer_deactivations: Mutex::new(
+                Queue::<peer_update::Index, PeerDeactivation>::new(QueueConfig {
+                    max_bindings_per_flush: 65_535,
+                    // peer_id, torrent_id, user_id
+                    bindings_per_record: 3,
+                    extra_bindings_per_flush: 0,
+                }),
+            ),
             torrents: Mutex::new(Queue::<torrent_update::Index, TorrentUpdate>::new(
                 QueueConfig {
                     max_bindings_per_flush: 65_535,
@@ -77,6 +91,7 @@ impl Queues {
             self.flush_announce_updates(state),
             self.histories.flush(state, "histories"),
             self.peers.flush(state, "peers"),
+            self.peer_deactivations.flush(state, "peer deactivations"),
             self.torrents.flush(state, "torrents"),
             self.users.flush(state, "users"),
             self.unregistered_info_hashes
@@ -111,6 +126,7 @@ impl Queues {
         !self.announces.lock().is_empty()
             || self.histories.lock().is_not_empty()
             || self.peers.lock().is_not_empty()
+            || self.peer_deactivations.lock().is_not_empty()
             || self.torrents.lock().is_not_empty()
             || self.users.lock().is_not_empty()
             || self.unregistered_info_hashes.lock().is_not_empty()

--- a/src/queue/peer_deactivation.rs
+++ b/src/queue/peer_deactivation.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+
+use sqlx::{MySql, QueryBuilder};
+
+use crate::state::AppState;
+
+use super::{peer_update::Index, Flushable, Mergeable};
+
+/// A queued request to mark a peer inactive in the database.
+///
+/// Emitted by the reaper ([`crate::scheduler::reap`]) when a peer transitions
+/// from active to inactive in the in-memory store. It carries no payload beyond
+/// its key: the only mutation is flipping the `active` flag off.
+///
+/// Without this, the reaper only ever mutates the in-memory store, so the peer's
+/// `active = 1` row lingers in the database forever. The [`super::peer_update`]
+/// flush only sets `active` from a live announce, and an explicit `stopped`
+/// event is the sole other path that writes `active = 0`. Any client that
+/// abandons a `peer_id` without sending `stopped` — qBittorrent regenerating its
+/// `peer_id` on restart/re-add, a crash, or a dropped connection — therefore
+/// leaves a ghost `active = 1` row, which surfaces as the same torrent appearing
+/// multiple times in UNIT3D's peer lists.
+#[derive(Clone, Copy)]
+pub struct PeerDeactivation;
+
+impl Mergeable for PeerDeactivation {
+    fn merge(&mut self, _new: &Self) {
+        // A deactivation carries no data beyond its key, so repeated
+        // deactivations of the same peer collapse to a single no-op merge.
+    }
+}
+
+impl Flushable<PeerDeactivation> for super::Batch<Index, PeerDeactivation> {
+    async fn flush_to_db(&self, state: &Arc<AppState>) -> Result<u64, sqlx::Error> {
+        if self.is_empty() {
+            return Ok(0);
+        }
+
+        // Only the `active` flag is touched, matched on the full primary key, so
+        // no other column is clobbered. This matters because the in-memory peer
+        // does not retain `ip`, `port`, `agent` or `left`, and by the time it is
+        // marked inactive both endpoints are already `None` — there is simply no
+        // faithful `PeerUpdate` to emit, and a synthetic one would overwrite good
+        // data via the `peer_update` upsert.
+        let mut query_builder: QueryBuilder<MySql> = QueryBuilder::new(
+            "UPDATE peers SET active = FALSE WHERE (peer_id, torrent_id, user_id) IN (",
+        );
+
+        let mut is_first = true;
+
+        for (index, _) in self.iter() {
+            if !is_first {
+                query_builder.push(", ");
+            }
+            is_first = false;
+
+            query_builder.push("(");
+            query_builder.push_bind(index.peer_id.to_vec());
+            query_builder.push(", ");
+            query_builder.push_bind(index.torrent_id);
+            query_builder.push(", ");
+            query_builder.push_bind(index.user_id);
+            query_builder.push(")");
+        }
+
+        query_builder.push(")");
+
+        query_builder
+            .build()
+            .persistent(false)
+            .execute(&state.pool)
+            .await
+            .map(|result| result.rows_affected())
+    }
+}

--- a/src/queue/peer_update.rs
+++ b/src/queue/peer_update.rs
@@ -28,10 +28,28 @@ pub struct PeerUpdate {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub connectable: bool,
+    pub ipv4: Option<IpAddr>,
+    pub ipv4_port: Option<u16>,
+    pub ipv4_connectable: Option<bool>,
+    pub ipv6: Option<IpAddr>,
+    pub ipv6_port: Option<u16>,
+    pub ipv6_connectable: Option<bool>,
 }
 
 impl Mergeable for PeerUpdate {
     fn merge(&mut self, new: &Self) {
+        // Merge dual-stack endpoints independently
+        if new.ipv4.is_some() {
+            self.ipv4 = new.ipv4;
+            self.ipv4_port = new.ipv4_port;
+            self.ipv4_connectable = new.ipv4_connectable;
+        }
+        if new.ipv6.is_some() {
+            self.ipv6 = new.ipv6;
+            self.ipv6_port = new.ipv6_port;
+            self.ipv6_connectable = new.ipv6_connectable;
+        }
+
         if new.updated_at > self.updated_at {
             self.ip = new.ip;
             self.port = new.port;
@@ -47,6 +65,13 @@ impl Mergeable for PeerUpdate {
         }
 
         self.created_at = std::cmp::min(self.created_at, new.created_at);
+    }
+}
+
+fn ip_to_bytes(ip: &IpAddr) -> Vec<u8> {
+    match ip {
+        IpAddr::V4(ip) => ip.octets().to_vec(),
+        IpAddr::V6(ip) => ip.octets().to_vec(),
     }
 }
 
@@ -74,7 +99,13 @@ impl Flushable<PeerUpdate> for super::Batch<Index, PeerUpdate> {
                         updated_at,
                         torrent_id,
                         user_id,
-                        connectable
+                        connectable,
+                        ipv4,
+                        ipv4_port,
+                        ipv4_connectable,
+                        ipv6,
+                        ipv6_port,
+                        ipv6_connectable
                     )
             "#,
         );
@@ -84,10 +115,7 @@ impl Flushable<PeerUpdate> for super::Batch<Index, PeerUpdate> {
             // Leading space required after the push values function
             .push_values(self.iter(), |mut bind, (index, peer_update)| {
                 bind.push_bind(index.peer_id.to_vec())
-                    .push_bind(match peer_update.ip {
-                        IpAddr::V4(ip) => ip.octets().to_vec(),
-                        IpAddr::V6(ip) => ip.octets().to_vec(),
-                    })
+                    .push_bind(ip_to_bytes(&peer_update.ip))
                     .push_bind(peer_update.port)
                     .push_bind(peer_update.agent.as_str())
                     .push_bind(peer_update.uploaded)
@@ -100,7 +128,13 @@ impl Flushable<PeerUpdate> for super::Batch<Index, PeerUpdate> {
                     .push_bind(peer_update.updated_at)
                     .push_bind(index.torrent_id)
                     .push_bind(index.user_id)
-                    .push_bind(peer_update.connectable);
+                    .push_bind(peer_update.connectable)
+                    .push_bind(peer_update.ipv4.as_ref().map(ip_to_bytes))
+                    .push_bind(peer_update.ipv4_port)
+                    .push_bind(peer_update.ipv4_connectable)
+                    .push_bind(peer_update.ipv6.as_ref().map(ip_to_bytes))
+                    .push_bind(peer_update.ipv6_port)
+                    .push_bind(peer_update.ipv6_connectable);
             })
             // Mysql 8.0.20 deprecates use of VALUES() so will have to update it eventually to use aliases instead
             // However, Mariadb doesn't yet support aliases
@@ -117,7 +151,13 @@ impl Flushable<PeerUpdate> for super::Batch<Index, PeerUpdate> {
                     seeder = VALUES(seeder),
                     visible = VALUES(visible),
                     updated_at = VALUES(updated_at),
-                    connectable = VALUES(connectable)
+                    connectable = VALUES(connectable),
+                    ipv4 = COALESCE(VALUES(ipv4), ipv4),
+                    ipv4_port = CASE WHEN VALUES(ipv4) IS NOT NULL THEN VALUES(ipv4_port) ELSE ipv4_port END,
+                    ipv4_connectable = CASE WHEN VALUES(ipv4) IS NOT NULL THEN VALUES(ipv4_connectable) ELSE ipv4_connectable END,
+                    ipv6 = COALESCE(VALUES(ipv6), ipv6),
+                    ipv6_port = CASE WHEN VALUES(ipv6) IS NOT NULL THEN VALUES(ipv6_port) ELSE ipv6_port END,
+                    ipv6_connectable = CASE WHEN VALUES(ipv6) IS NOT NULL THEN VALUES(ipv6_connectable) ELSE ipv6_connectable END
             "#,
             );
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -38,6 +38,8 @@ pub async fn reap(state: &Arc<AppState>) {
     let mut torrent_store = state.stores.torrents.lock();
 
     torrent_store.par_values_mut().for_each(|torrent| {
+        // Copied out so it can be read while `torrent.peers` is borrowed mutably.
+        let torrent_id = torrent.id;
         let mut seeder_delta: i32 = 0;
         let mut leecher_delta: i32 = 0;
 
@@ -48,30 +50,59 @@ pub async fn reap(state: &Arc<AppState>) {
             .retain(|_, peer| inactive_cutoff <= peer.updated_at || peer.is_active);
 
         for (index, peer) in torrent.peers.iter_mut() {
-            // Peers get marked as inactive if not announced for more than
-            // active_peer_ttl seconds. User peer count and torrent peer
-            // count are updated to reflect.
-            if peer.updated_at < active_cutoff && peer.is_active {
-                if peer.is_included_in_peer_list(&config) {
-                    state
-                        .stores
-                        .users
-                        .write()
-                        .entry(index.user_id)
-                        .and_modify(|user| {
-                            if peer.is_seeder {
-                                user.num_seeding = user.num_seeding.saturating_sub(1);
-                            } else {
-                                user.num_leeching = user.num_leeching.saturating_sub(1);
-                            }
-                        });
-                    match peer.is_seeder {
-                        true => seeder_delta -= 1,
-                        false => leecher_delta -= 1,
-                    }
-                }
+            let was_included = peer.is_included_in_peer_list(&config);
+            let was_seeder = peer.is_seeder;
 
+            // Expire individual endpoints based on their own updated_at
+            if peer.ipv4.is_some_and(|ep| ep.updated_at < active_cutoff) {
+                peer.ipv4 = None;
+            }
+            if peer.ipv6.is_some_and(|ep| ep.updated_at < active_cutoff) {
+                peer.ipv6 = None;
+            }
+
+            // If all endpoints are gone, mark peer inactive
+            if peer.ipv4.is_none() && peer.ipv6.is_none() && peer.is_active {
                 peer.is_active = false;
+
+                // Propagate the deactivation to the database. The reaper only
+                // mutates the in-memory store; the peer_update flush sets
+                // `active` solely from a live announce and an explicit `stopped`
+                // is the only other path that clears it. Without this enqueue a
+                // client that abandons a peer_id without sending `stopped`
+                // (qBittorrent regenerating its peer_id on restart/re-add, a
+                // crash, a dropped connection) leaves a ghost `active = 1` row,
+                // which shows up as the torrent appearing once per stale peer_id
+                // in UNIT3D's peer lists.
+                state.queues.peer_deactivations.lock().upsert(
+                    crate::queue::peer_update::Index {
+                        user_id: index.user_id,
+                        torrent_id,
+                        peer_id: index.peer_id,
+                    },
+                    crate::queue::peer_deactivation::PeerDeactivation,
+                );
+            }
+
+            let is_included = peer.is_included_in_peer_list(&config);
+
+            if was_included && !is_included {
+                state
+                    .stores
+                    .users
+                    .write()
+                    .entry(index.user_id)
+                    .and_modify(|user| {
+                        if was_seeder {
+                            user.num_seeding = user.num_seeding.saturating_sub(1);
+                        } else {
+                            user.num_leeching = user.num_leeching.saturating_sub(1);
+                        }
+                    });
+                match was_seeder {
+                    true => seeder_delta -= 1,
+                    false => leecher_delta -= 1,
+                }
             }
         }
 

--- a/src/store/peer.rs
+++ b/src/store/peer.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::net::IpAddr;
 use std::ops::{Deref, DerefMut};
 
 use chrono::serde::ts_seconds;
@@ -23,13 +24,21 @@ pub struct Index {
 }
 
 #[derive(Clone, Copy, Debug, Serialize)]
-pub struct Peer {
-    pub ip_address: std::net::IpAddr,
+pub struct Endpoint {
+    pub ip: IpAddr,
     pub port: u16,
+    pub is_connectable: bool,
+    #[serde(with = "ts_seconds")]
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+pub struct Peer {
+    pub ipv4: Option<Endpoint>,
+    pub ipv6: Option<Endpoint>,
     pub is_seeder: bool,
     pub is_active: bool,
     pub is_visible: bool,
-    pub is_connectable: bool,
     pub has_sent_completed: bool,
     #[serde(with = "ts_seconds")]
     pub updated_at: DateTime<Utc>,
@@ -38,11 +47,16 @@ pub struct Peer {
 }
 
 impl Peer {
-    /// Determines if the peer should be included in the peer list
+    #[inline(always)]
+    pub fn is_connectable(&self) -> bool {
+        self.ipv4.is_some_and(|ep| ep.is_connectable)
+            || self.ipv6.is_some_and(|ep| ep.is_connectable)
+    }
+
     #[inline(always)]
     pub fn is_included_in_peer_list(&self, config: &Config) -> bool {
         if config.require_peer_connectivity {
-            self.is_active && self.is_visible && self.is_connectable
+            self.is_active && self.is_visible && self.is_connectable()
         } else {
             self.is_active && self.is_visible
         }

--- a/src/store/torrent.rs
+++ b/src/store/torrent.rs
@@ -10,7 +10,7 @@ use sqlx::types::chrono::{DateTime, Utc};
 use anyhow::{Context, Result};
 
 use crate::model::{peer_id::PeerId, torrent_status::TorrentStatus};
-use crate::store::peer::{Index, Peer, PeerStore};
+use crate::store::peer::{Endpoint, Index, Peer, PeerStore};
 
 pub struct TorrentStore {
     inner: IndexMap<u32, Torrent>,
@@ -93,13 +93,64 @@ impl TorrentStore {
                     peers.updated_at as `updated_at: DateTime<Utc>`,
                     peers.uploaded as `uploaded: u64`,
                     peers.downloaded as `downloaded: u64`,
-                    peers.peer_id as `peer_id: PeerId`
+                    peers.peer_id as `peer_id: PeerId`,
+                    INET6_NTOA(peers.ipv4) as `ipv4_address: Option<IpAddr>`,
+                    peers.ipv4_port as `ipv4_port: Option<u16>`,
+                    peers.ipv4_connectable as `ipv4_connectable: Option<bool>`,
+                    INET6_NTOA(peers.ipv6) as `ipv6_address: Option<IpAddr>`,
+                    peers.ipv6_port as `ipv6_port: Option<u16>`,
+                    peers.ipv6_connectable as `ipv6_connectable: Option<bool>`
                 FROM
                     peers
             "#
         )
         .fetch(db)
         .try_fold(torrents, |mut store, peer| async move {
+            let updated_at = peer
+                .updated_at
+                .expect("Peer with a null updated_at found in database.");
+
+            let legacy_ip = peer
+                .ip_address
+                .expect("INET6_NTOA failed to decode peer ip.");
+
+            // Use new dual-stack columns if available, fall back to legacy ip column
+            let ipv4 = if let Some(ip) = peer.ipv4_address.flatten() {
+                Some(Endpoint {
+                    ip,
+                    port: peer.ipv4_port.flatten().unwrap_or(peer.port),
+                    is_connectable: peer.ipv4_connectable.flatten().unwrap_or(false),
+                    updated_at,
+                })
+            } else if matches!(legacy_ip, IpAddr::V4(_)) && peer.ipv6_address.flatten().is_none() {
+                Some(Endpoint {
+                    ip: legacy_ip,
+                    port: peer.port,
+                    is_connectable: peer.is_connectable,
+                    updated_at,
+                })
+            } else {
+                None
+            };
+
+            let ipv6 = if let Some(ip) = peer.ipv6_address.flatten() {
+                Some(Endpoint {
+                    ip,
+                    port: peer.ipv6_port.flatten().unwrap_or(peer.port),
+                    is_connectable: peer.ipv6_connectable.flatten().unwrap_or(false),
+                    updated_at,
+                })
+            } else if matches!(legacy_ip, IpAddr::V6(_)) && peer.ipv4_address.flatten().is_none() {
+                Some(Endpoint {
+                    ip: legacy_ip,
+                    port: peer.port,
+                    is_connectable: peer.is_connectable,
+                    updated_at,
+                })
+            } else {
+                None
+            };
+
             store.entry(peer.torrent_id).and_modify(|torrent| {
                 torrent.peers.insert(
                     Index {
@@ -107,18 +158,13 @@ impl TorrentStore {
                         peer_id: peer.peer_id,
                     },
                     Peer {
-                        ip_address: peer
-                            .ip_address
-                            .expect("INET6_NTOA failed to decode peer ip."),
-                        port: peer.port,
+                        ipv4,
+                        ipv6,
                         is_seeder: peer.is_seeder,
                         is_active: peer.is_active,
                         is_visible: peer.is_visible,
-                        is_connectable: peer.is_connectable,
                         has_sent_completed: false,
-                        updated_at: peer
-                            .updated_at
-                            .expect("Peer with a null updated_at found in database."),
+                        updated_at,
                         uploaded: peer.uploaded,
                         downloaded: peer.downloaded,
                     },


### PR DESCRIPTION
# feat: dual-stack (IPv4/IPv6) peer support

## Summary

Adds dual-stack (IPv4/IPv6) support so the tracker handles clients that announce
over both address families, per **BEP 7**. Each peer's IPv4 and IPv6 endpoints
are tracked independently — recorded from the connection source, connectivity-
checked per family, and returned as separate `peers` (BEP 23) and `peers6`
(BEP 7) compact lists.

> **Companion PR** — the matching database columns and UI live in UNIT3D:
> `lluiseduardo-silva/UNIT3D` (branch `feat/dual-stack-ipv6`). The two are meant
> to ship together — this tracker writes the `ipv4`/`ipv6` peer columns that the
> UNIT3D migration adds. [PR](https://github.com/HDInnovations/UNIT3D/pull/5536)

## Changes

- **announce**: take the connection source as the peer IP, populate the matching
  family's endpoint, and run the connectable check per family.
- **store** (`peer`, `torrent`): hold optional `ipv4`/`ipv6` endpoints per peer;
  expire and count them independently.
- **queue/peer_update**: upsert both families, merging each independently.
- **scheduler/reap**: expire endpoints per family; deactivate a peer once both
  are gone.
- **queue/peer_deactivation** (new): propagate reaper deactivations to the
  database. Previously the reaper only mutated the in-memory store, so a peer
  abandoned without a `stopped` event (e.g. a new `peer_id` after a client
  restart/re-add, a crash, or a dropped connection) left a stale `active = 1`
  row and surfaced as a **duplicate peer** in UNIT3D's lists.
- **main**: tuple match instead of let-chains so it builds on Rust 1.87.

## Evidence

**Internal model** — each peer carries separate `ipv4`/`ipv6` endpoints with
per-family connectability:

```json
"ipv4": { "ip": "10.0.1.108",            "port": 62914, "is_connectable": true },
"ipv6": { "ip": "::be24:11ff:fe6b:3d0e", "port": 62914, "is_connectable": true }
```

**Announce response** — both families returned (BEP 23 `peers` + BEP 7 `peers6`):

```
peers   (IPv4, 6 bytes):   10.0.1.108:62914
peers6  (IPv6, 18 bytes):  [::be24:11ff:fe6b:3d0e]:62914
```

Full reproducible `curl` commands and raw responses in the attached evidence
doc. Real dual-stack download confirmed at the client (qBittorrent connected to
the same seeder over IPv4 and IPv6 at once). Ghost-peer fix verified —
duplicate/stale `active = 1` rows no longer appear after a `peer_id` change
(before/after in the companion UNIT3D PR).

## Notes

- Requires the companion UNIT3D migration (nullable `ipv4`/`ipv6` +
  `*_port`/`*_connectable` columns on `peers`).
- Per-family connectivity check is gated by `IS_CONNECTIVITY_CHECK_ENABLED`.